### PR TITLE
Adding knexfile att4

### DIFF
--- a/config/connection.js
+++ b/config/connection.js
@@ -8,7 +8,11 @@ const mysql = require('mysql')
 /* eslint-enable  no-unused-vars */
 
 // Creates mySQL connection using Knex.js
-const Knex = require('knex')(require('../knexfile')[ENV])
+// below is the original line of code, commented out
+// const Knex = require('knex')(require('../knexfile')[ENV])
+/* below is the edited line of code, removing [ENV] because I didn't just want to
+disable that linter rule */
+const Knex = require('knex')(require('../knexfile'))
 
 // Exports the connection for other files to use
 module.exports = Knex

--- a/knexfile.js
+++ b/knexfile.js
@@ -1,0 +1,44 @@
+// Update with your config settings.
+
+module.exports = {
+
+  development: {
+    client: 'mysql',
+    connection: {
+      filename: './dev.mysql'
+    }
+  },
+
+  staging: {
+    client: 'mysql',
+    connection: {
+      database: 'quotes_db',
+      user: 'username',
+      password: 'password'
+    },
+    pool: {
+      min: 2,
+      max: 10
+    },
+    migrations: {
+      tableName: 'quotes_migrations'
+    }
+  },
+
+  production: {
+    client: 'mysql',
+    connection: {
+      database: 'quotes_db',
+      user: 'username',
+      password: 'password'
+    },
+    pool: {
+      min: 2,
+      max: 10
+    },
+    migrations: {
+      tableName: 'quotes'
+    }
+  }
+
+}

--- a/models/example.js
+++ b/models/example.js
@@ -12,7 +12,7 @@ const knex = require('../config/connection.js')
  * @class Example
  */
 class Example {
-  constructor(table = 'example') {
+  constructor (table = 'example') {
     this.table = table
   }
 
@@ -22,7 +22,7 @@ class Example {
    * @returns Promise
    * @memberof Example
    */
-  findAll() {
+  findAll () {
     return knex.select()
       .table(this.table)
   }
@@ -34,7 +34,7 @@ class Example {
  * @returns Promise
  * @memberof Example
  */
-  create(values) {
+  create (values) {
     return knex(this.table)
       .returning('id')
       .insert(values)
@@ -47,7 +47,7 @@ class Example {
    * @returns Promise
    * @memberof Example
    */
-  destroy(where) {
+  destroy (where) {
     return knex(this.table)
       .where(where)
       .del()

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -1,3 +1,5 @@
+/* global alert, fetch */
+
 // Get references to page elements
 var exampleText = document.querySelector('#example-text')
 var exampleDescription = document.querySelector('#example-description')
@@ -6,11 +8,11 @@ var exampleList = document.querySelector('#example-list')
 
 // The API object contains methods for each kind of request we'll make
 class API {
-  constructor(someDefault = 'defaultVal') {
+  constructor (someDefault = 'defaultVal') {
     this.someDefault = someDefault
   }
 
-  saveExample(example) {
+  saveExample (example) {
     return fetch('api/examples', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -18,11 +20,11 @@ class API {
     })
   }
 
-  getExamples() {
+  getExamples () {
     return fetch('api/examples')
   }
 
-  deleteExample(id) {
+  deleteExample (id) {
     return fetch('api/examples/' + id, {
       method: 'DELETE'
     })

--- a/server.js
+++ b/server.js
@@ -6,12 +6,15 @@ require('dotenv').config()
 
 const express = require('express')
 const exphbs = require('express-handlebars')
-
-const db = require('./models/example') // eslint-disable no-unused-consts
+/* eslint-disable no-unused-vars */
+const db = require('./models/example')
+/* eslint-enable no-unused-vars */
 
 const app = express()
 const PORT = process.env.PORT || 3000
+/* eslint-disable no-unused-vars */
 const ENV = process.env.NODE_ENV || 'development'
+/* eslint-enable no-unused-vars */
 
 // Middleware
 app.use(express.urlencoded({ extended: false }))

--- a/test/canary.test.js
+++ b/test/canary.test.js
@@ -1,9 +1,12 @@
-var expect = require("chai").expect;
+var expect = require('chai').expect
 
-describe("canary test", function() {
+/* eslint-disable no-undef, no-unused-expressions */
+describe('canary test', function () {
   // A "canary" test is one we set up to always pass
   // This can help us ensure our testing suite is set up correctly before writing real tests
-  it("should pass this canary test", function() {
-    expect(true).to.be.true;
-  });
-});
+  it('should pass this canary test', function () {
+    expect(true).to.be.true
+  })
+})
+
+/* eslint-enable no-undef, no-unused-expressions */

--- a/test/canary.test.js
+++ b/test/canary.test.js
@@ -1,6 +1,7 @@
 var expect = require('chai').expect
 
 /* eslint-disable no-undef, no-unused-expressions */
+
 describe('canary test', function () {
   // A "canary" test is one we set up to always pass
   // This can help us ensure our testing suite is set up correctly before writing real tests


### PR DESCRIPTION
updated three files (connection.js, example.js, and server.js) according to Travis CI errors, also added knexfile and updated the canary.test.js and index.js files. last time the Travis CI gave an error about the describe function and that might happen again since disabling the eslint rule did not seem to affect it getting caught in Travis CI.